### PR TITLE
date_validator: Updated regex

### DIFF
--- a/eprihlaska/validators.py
+++ b/eprihlaska/validators.py
@@ -51,7 +51,7 @@ class DateValidator:
         self.val_err_msg = val_err_msg
 
     def __call__(self, form, field):
-        date_reg = re.compile(r'^(\d\d)\.(\d\d)\.(\d\d\d\d)$')
+        date_reg = re.compile(r'^(\d?\d)\.(\d?\d)\.(\d\d\d\d)$')
         mo = date_reg.search(field.data)
 
         try:


### PR DESCRIPTION
* Regex now accepts both D.M.YYYY and DD.MM.YYYY formats.
* Fixes: #57 

Signed-off-by: JakubNvk <jakub.novak@gmail.com>