### PR TITLE
refactor: Deal with length_of_study in templates

### DIFF
--- a/eprihlaska/templates/application_form.html
+++ b/eprihlaska/templates/application_form.html
@@ -3,6 +3,8 @@
 {% import "bootstrap/fixes.html" as fixes %}
 {% import "bootstrap/utils.html" as util %}
 
+{% set los = session['length_of_study'] or '0' %}
+
  {% block metas %}
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -262,7 +264,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <strong>{{ consts.LENGTH_OF_STUDY }}:</strong> {{ label_length_of_study }}
+          <strong>{{ consts.LENGTH_OF_STUDY }}:</strong> {{ dict(consts.LENGTH_OF_STUDY_CHOICES)[los] }}
        </div>
       </div>
 

--- a/eprihlaska/templates/grade_listing_table.html
+++ b/eprihlaska/templates/grade_listing_table.html
@@ -1,9 +1,11 @@
+      {% set los = session['length_of_study'] or '0' %}
+
       <table  class="table" cellspacing="5" cellpadding="5">
         <tr>
           <th>Predmet</th>
-          <th>{{ label_first_year }}</th>
-          <th>{{ label_second_year }}</th>
-          <th>{{ label_third_year }}</th>
+          <th>{{ consts.GRADE_FIRST_YEAR[los] }}</th>
+          <th>{{ consts.GRADE_SECOND_YEAR[los] }}</th>
+          <th>{{ consts.GRADE_THIRD_YEAR[los] }}</th>
         </tr>
 
         {% if 'grades_mat' in session and 'grade_first_year' in session['grades_mat'] %}

--- a/eprihlaska/views.py
+++ b/eprihlaska/views.py
@@ -479,14 +479,11 @@ def payment_receipt():
 @app.route('/grades_control', methods=['GET'])
 @login_required
 def grades_control():
-    los = session['length_of_study']
-
     app = ApplicationForm.query.filter_by(user_id=current_user.id).first()
-    rendered = render_template('grade_listing.html', session=session,
+    rendered = render_template('grade_listing.html',
+                               session=session,
                                id=app.id,
-                               label_first_year=consts.GRADE_FIRST_YEAR[los],
-                               label_second_year=consts.GRADE_SECOND_YEAR[los],
-                               label_third_year=consts.GRADE_THIRD_YEAR[los])
+                               consts=consts)
 
     pdf = generate_pdf(rendered, options={'orientation': 'landscape'})
 
@@ -502,19 +499,12 @@ def render_app(app, print=False, use_app_session=True):
     if use_app_session:
         sess = flask.json.loads(app.application)
 
-    los = sess['length_of_study']
-    label_length_of_study = dict(consts.LENGTH_OF_STUDY_CHOICES)[los]
-
     specific_symbol = 10000 + app.id
     rendered = render_template('application_form.html', session=sess,
                                lists=LISTS, id=app.id,
                                specific_symbol=specific_symbol,
                                submitted_at=app.submitted_at,
-                               consts=consts, print=print,
-                               label_first_year=consts.GRADE_FIRST_YEAR[los],
-                               label_second_year=consts.GRADE_SECOND_YEAR[los],
-                               label_third_year=consts.GRADE_THIRD_YEAR[los],
-                               label_length_of_study=label_length_of_study)
+                               consts=consts, print=print)
     return rendered
 
 


### PR DESCRIPTION
* Previously, `length_of_study` has been dealt with at the
  business-logic level. This has proven unfortunate, as not filling this
  value meant a lot of rendering has been broken.

* This commit refactors the whole story around `length_of_study`, puts
  the code that handles what gets shown when into templates and deals
  with them on that level. This allows the whole process to be more
  resilient to 'data-not-filled-yet' situations.

Signed-off-by: mr.Shu <mr@shu.io>