### PR TITLE
fix: Stray mentions of 2018

### DIFF
--- a/eprihlaska/forms.py
+++ b/eprihlaska/forms.py
@@ -188,7 +188,7 @@ class CompetitionSuccessFormItem(FlaskForm):
     year = IntegerField(label=c.COMPETITION_YEAR,
                         validators=[validators.Optional(),
                                     validators.NumberRange(min=1990,
-                                                           max=2018,
+                                                           max=c.CURRENT_MATURA_YEAR,
                                                            message=c.YEAR_ERR)])
     further_info = StringField(label=c.COMPETITION_FURTHER_INFO,
                                description=c.COMPETITION_FURTHER_INFO_DESC)

--- a/eprihlaska/templates/application_form.html
+++ b/eprihlaska/templates/application_form.html
@@ -24,10 +24,8 @@
           <img src="{{ url_for('static', filename='img/fmfi-logo.jpg', _external=True) }}" style="height: 150px; width: 150px" alt=""/>
         </div>
         <div class="col-lg-8">
-          <strong>Univerzita:</strong> Univerzita Komenského v Bratislave <br />
-          <strong>Fakulta:</strong> Fakulta matematiky, fyziky a informatiky  <br />
-          <strong>Akademický rok:</strong> 2018/2019 <br />
-          <strong>Evidenčné číslo prihlášky:</strong> eprih-2018-{{ id }} <br />
+          {% include "application_form_header.html" %}
+
           {% if not (session['basic_personal_data']['dean_invitation_letter'] and session['basic_personal_data']['dean_invitation_letter_no']) %}
            <hr>
            Poplatok za prijímacie konanie vo výške 33 EUR je potrebné uhradiť na účet: <br>

--- a/eprihlaska/templates/application_form_header.html
+++ b/eprihlaska/templates/application_form_header.html
@@ -1,0 +1,4 @@
+          <strong>Univerzita:</strong> Univerzita Komenského v Bratislave <br />
+          <strong>Fakulta:</strong> Fakulta matematiky, fyziky a informatiky  <br />
+          <strong>Akademický rok:</strong> {{ consts.CURRENT_MATURA_YEAR }}/{{ consts.CURRENT_MATURA_YEAR + 1 }} <br />
+          <strong>Evidenčné číslo prihlášky:</strong> eprih-{{ consts.CURRENT_MATURA_YEAR }}-{{ id }} <br />

--- a/eprihlaska/templates/final.html
+++ b/eprihlaska/templates/final.html
@@ -141,7 +141,7 @@ Odovzdané potvrdenie o zaplatení si môžete skontrolovať na nasledujúcej li
 {% endif %}
 
 <h3>Overená kópia maturitného vysvedčenia</h3>
-{% if session['basic_personal_data']['matura_year'] == 2018 %}
+{% if session['basic_personal_data']['matura_year'] == consts.CURRENT_MATURA_YEAR %}
 
 <p>
 Po skončení maturity nám bezodkladne pošlite overenú kópiu maturitného

--- a/eprihlaska/templates/grade_listing.html
+++ b/eprihlaska/templates/grade_listing.html
@@ -22,10 +22,7 @@
         </div>
 
         <div class="col-lg-8">
-          <strong>Univerzita:</strong> Univerzita Komenského v Bratislave <br />
-          <strong>Fakulta:</strong> Fakulta matematiky, fyziky a informatiky  <br />
-          <strong>Akademický rok:</strong> 2018/2019 <br />
-          <strong>Evidenčné číslo prihlášky:</strong> eprih-2018-{{ id }} <br />
+          {% include "application_form_header.html" %}
         </div>
       </div>
     </div>

--- a/eprihlaska/views.py
+++ b/eprihlaska/views.py
@@ -460,7 +460,8 @@ def final():
                            hs_ed_level_check=hs_education_level_check,
                            grades_filled=grades_filled,
                            app_state=app_state,
-                           form=form, receipt_form=receipt_form)
+                           form=form, receipt_form=receipt_form,
+                           consts=consts)
 
 
 @app.route('/payment_receipt', methods=['GET'])


### PR DESCRIPTION
* Remove all hardcoded mentions of 2018 that could be replaced with an
  easily-changeable constant, specifically in:

  - final.html
  - forms.py
  - application_form.html
  - grade_listing.html

* Refactor common part of grade listing form and application form into a
  separate template.

* Fix #146

Signed-off-by: mr.Shu <mr@shu.io>