### PR TITLE
fix: prevent accessing non-existing data from dict

### DIFF
--- a/eprihlaska/views.py
+++ b/eprihlaska/views.py
@@ -716,8 +716,10 @@ def google_authorize():
     token = google.authorize_access_token()
     profile = google.parse_openid(token)
 
-    create_or_get_user_and_login('google', token, profile.data['given_name'],
-                                 profile.data['family_name'], profile.email)
+    create_or_get_user_and_login('google', token,
+                                 profile.data.get('given_name', ''),
+                                 profile.data.get('family_name', ''),
+                                 profile.email)
 
     return redirect(url_for('study_programme'))
 


### PR DESCRIPTION
* google allows users not to fill family_name

Signed-off-by: Adrian Matejov <ado.matejov@gmail.com>