### PR TITLE
update: Deal with empty `name` from Facebook

### DIFF
--- a/eprihlaska/views.py
+++ b/eprihlaska/views.py
@@ -738,7 +738,7 @@ def facebook_authorize():
     token = facebook.authorize_access_token()
     profile = facebook.fetch_user()
 
-    data = profile.data['name'].split(' ')
+    data = profile.data.get('name', '').split(' ')
     name = '' if not len(data) else data[0]
     surname = '' if len(data) <= 1 else data[-1]
 


### PR DESCRIPTION
* OAuth sometimes returns an empty `name`.

* This commit deals with that.

Signed-off-by: mr.Shu <mr@shu.io>