### PR TITLE
forms: Ensure names do not contain numbers

### DIFF
--- a/eprihlaska/consts.py
+++ b/eprihlaska/consts.py
@@ -12,6 +12,7 @@ DEAN_LIST_MSG = _('Na základe listu dekana nie je potrebné zadávať údaje o 
 LOGIN_CONGRATS_MSG = _('Gratulujeme, boli ste prihlásení do prostredia ePrihlaska!')  # noqa
 PASSWD_CHANGED_MSG = _('Gratulujeme, Vaše heslo bolo nastavené! Prihláste sa ním, prosím, nižšie.')  # noqa
 INVALID_TOKEN_MSG = _('Váš token na zmenu hesla je neplatný. Vyplnte prosím Váš email znovu.')  # noqa
+INVALID_NAME_MSG = _('Meno a priezvisko nesmie obsahovať znaky 0-9 alebo /')  # noqa
 
 SUBMISSIONS_NOT_OPEN = _('Podávanie prihlášok momentálne nie je otvorené.')
 

--- a/eprihlaska/forms.py
+++ b/eprihlaska/forms.py
@@ -70,10 +70,16 @@ class BasicPersonalDataForm(FlaskForm):
     personal_info_check = BooleanField(label=c.PERSONAL_INFO_CHECK,
                                        validators=[validators.DataRequired()])
     name = StringField(label=c.NAME,
-                       validators=[validators.DataRequired()])
+                       validators=[validators.DataRequired(),
+                                   validators.Regexp(r'[^0-9/]+',
+                                                     message=c.INVALID_NAME_MSG)])
     surname = StringField(label=c.SURNAME,
-                          validators=[validators.DataRequired()])
-    born_with_surname = StringField(c.BORNWITH_SURNAME)
+                          validators=[validators.DataRequired(),
+                                      validators.Regexp(r'[^0-9/]+',
+                                                        message=c.INVALID_NAME_MSG)])
+    born_with_surname = StringField(c.BORNWITH_SURNAME,
+                                    validators=[validators.Regexp(r'[^0-9/]+',
+                                                                  message=c.INVALID_NAME_MSG)])
 
     matura_year = IntegerField(c.MATURA_YEAR,
                                default=c.DEFAULT_MATURA_YEAR,


### PR DESCRIPTION
* Ensure name and surname(s) do not contain numbers and `/` signs --
  sometimes especially the `born_with_surname` got mistaken for the
  `birth_no`.

Signed-off-by: mr.Shu <mr@shu.io>