### PR TITLE
Add admin login with SAML + Andrvotr instead of Cosign

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "eprihlaska/votr"]
-	path = eprihlaska/votr
-	url = https://github.com/fmfi-svt/votr.git

--- a/config-sample.py
+++ b/config-sample.py
@@ -30,7 +30,8 @@ ERROR_EMAIL_HEADER = 'ePrihlaska - error'
 
 UA_CODE = 'UA-23362538-7'
 
-COSIGN_PROXY_DIR = '/opt/cosign/proxy'
+MY_ENTITY_ID = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+ANDRVOTR_API_KEY = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 
 SUBMISSIONS_OPEN = True
 UPLOADS_ENABLED = True

--- a/eprihlaska/ais_utils.py
+++ b/eprihlaska/ais_utils.py
@@ -1,19 +1,26 @@
-import os
 import sys
 import re
 import flask.json
 from flask import url_for
-DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, DIR + '/votr/')
-
-from aisikl.context import Context # noqa
 from aisikl.app import Application # noqa
 import aisikl.portal # noqa
+from fladgejt.login import create_client # noqa
 
 
-def create_context(cookies, origin='ais2-beta.uniba.sk'):
-    ctx = Context(cookies, ais_url='https://'+origin+'/')
-    return ctx
+def create_context(*,
+                   my_entity_id,
+                   andrvotr_api_key,
+                   andrvotr_authority_token,
+                   beta):
+    ais_url = 'https://ais2-beta.uniba.sk/' if beta else 'https://ais2.uniba.sk/'
+    server = dict(login_types=('saml_andrvotr',), ais_url=ais_url)
+    params = dict(
+        type='saml_andrvotr',
+        my_entity_id=my_entity_id,
+        andrvotr_api_key=andrvotr_api_Key,
+        andrvotr_authority_token=andrvotr_authority_token,
+    )
+    return create_client(server, params).context
 
 
 def test_ais(ctx):

--- a/eprihlaska/views.py
+++ b/eprihlaska/views.py
@@ -986,29 +986,21 @@ def admin_file_download(id, uuid):
     return send_from_directory(receipt_dir, file, as_attachment=True)
 
 
-def get_cosign_cookies():
-    name = request.environ['COSIGN_SERVICE']
-    value = request.cookies[name]
-    filename = name + '=' + value.partition('/')[0]
-    result = {}
-    with open(os.path.join(app.config['COSIGN_PROXY_DIR'],
-                           filename)) as f:
-        for line in f:
-            # Remove starting "x" and everything after the space.
-            name, _, value = line[1:].split()[0].partition('=')
-            result[name] = value
-    return result
+def create_votr_context(*, beta):
+    from .ais_utils import create_context
+    return create_context(
+        my_entity_id=app.config['MY_ENTITY_ID'],
+        andrvotr_api_key=app.config['ANDRVOTR_API_KEY'],
+        andrvotr_authority_token=request.environ['ANDRVOTR_AUTHORITY_TOKEN'],
+        beta=beta,
+    )
 
 
 @app.route('/admin/ais_test')
 @require_remote_user
 def admin_ais_test():
-    from .ais_utils import (create_context, test_ais)
-    cosign_cookies = get_cosign_cookies()
-    ctx = create_context(cosign_cookies,
-                         origin='ais2.uniba.sk')
-    # Do log in
-    ctx.request_html('/ais/loginCosign.do', method='POST')
+    from .ais_utils import test_ais
+    ctx = create_votr_context(beta=False)
     test_ais(ctx)
     return redirect(url_for('admin_list'))
 
@@ -1158,17 +1150,9 @@ def admin_process_special(id, process_type):
 
 
 def send_application_to_ais2(id, application, form, process_type, beta=False):
-    from .ais_utils import (create_context, save_application_form)
+    from .ais_utils import save_application_form
     if form.validate_on_submit():
-        origin = 'ais2.uniba.sk'
-        if beta:
-            origin = 'ais2-beta.uniba.sk'
-
-        cosign_cookies = get_cosign_cookies()
-        ctx = create_context(cosign_cookies,
-                             origin=origin)
-        # Do log in
-        ctx.request_html('/ais/loginCosign.do', method='POST')
+        ctx = create_votr_context(beta=beta)
 
         ais2_output = None
         error_output = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ SQLAlchemy==1.3.0
 tinycss2==0.6.1
 urllib3==1.26.5
 visitor==0.1.3
+votr @ git+https://github.com/fmfi-svt/votr.git@2f4a488747f131b8d413b6879a41663e9fbc2880
 WeasyPrint==0.42
 webencodings==0.5.1
 Werkzeug==0.15.3


### PR DESCRIPTION
Asi pre @mrshu, ledaže by @Adman.

PR upgraduje Votr-knižnicu na novú verziu a používa nové prihlasovanie typu saml_andrvotr.
Navyše Votr už sa dá inštalovať ako normálny python balík, netreba submodule ani meniť sys.path.

Z pohľadu eprihlášky to bude vyzerať takto: Namiesto mod_cosign tam bude nejaký iný modul, buď mod_auth_mellon alebo mod_shib. Bude nastavený že /admin/* vyžaduje prihlásenie od malej povolenej množiny userov, rovnako ako doteraz bol mod_cosign. Keď sa niekto prihlási, v request.environ dostaneme tzv. andrvotr authority token, ktorý v podstate nejako kóduje, kto a kedy sa prihlásil kam (do eprihlášky). Potom stačí inicializovať Votr client s parametrami type="saml_andrvotr", my_entity_id=(konštanta z configu), andrvotr_api_key=(konštanta z configu), andrvotr_authority_token=(hodnota z request.environ). Votr sa pomocou toho prihlási do aisu.

Nie je to úplne dokončené. Čo ešte treba, aby niekto spravil (radšej nie ja):

- Nie je to absolútne vôbec otestované (ani syntax errors) lebo sa mi nepodarilo nainštalovať requirements.txt. Možno treba #237. BTW vo Votri som vyskúšal `uv` a dosť sa mi páči, ale aj `poetry` je ok ak chceš.
- Hlavný otvorený problém je že andrvotr authority token rýchlo vyprší (po 5 minútach). Ideálne by bolo zavolať create_context / create_client iba raz, vtedy keď užívateľ prvýkrát príde do /admin/, a uložiť ho vo Flask session. Ale neviem ako to v eprihláške funguje, lebo existuje aj normálne užívateľské prihlasovanie aj admin login. eprihlaska/views.py robí so session nejaké veci ktorým nerozumiem, moc som sa v tom nevŕtal.
- Zatiaľ je tam votr commit hash z WIP commitu ktorý neskôr squashnem. Potom treba updatnuť.
- V templates je hardcoded `https://login.uniba.sk/logout.cgi`, bude treba zmeniť, závisí od vybraného modulu.
- Odporúčam upgradnuť svt5 Ubuntu. Neviem s akým starým pythonom to bude fungovať. Aj tak všeobecne už by sa patrilo.